### PR TITLE
build: remove dir sources to fix package build issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,9 +50,6 @@ dev = [
 [tool.hatch.metadata.hooks.requirements_txt]
 files = ["requirements.txt"]
 
-[tool.hatch.build]
-sources = ["src"]
-
 [tool.hatch.version]
 source = "vcs"
 


### PR DESCRIPTION
## Overview

This PR fixes the package build issue so that it doesn't try to find dynamically generated file in `src/` once built.