### PR TITLE
style: Remove * imports, fixes F403 PEP violation

### DIFF
--- a/src/caustics/__init__.py
+++ b/src/caustics/__init__.py
@@ -1,16 +1,23 @@
 from ._version import version as VERSION  # noqa
 
-from .constants import *
-from .lenses import *
-from .cosmology import *
-from .packed import *
-from .parametrized import *
-from .light import *
-from .utils import *
-from .sims import *
-from .tests import *
+from . import constants, lenses, cosmology, packed, parametrized, light, utils, sims
+from .tests import test
 
 # from .demo import *
 
 __version__ = VERSION
 __author__ = "Ciela"
+
+__all__ = [
+    # Modules
+    "constants",
+    "lenses",
+    "cosmology",
+    "packed",
+    "parametrized",
+    "light",
+    "utils",
+    "sims",
+    # Functions
+    "test",
+]

--- a/src/caustics/data/__init__.py
+++ b/src/caustics/data/__init__.py
@@ -1,3 +1,3 @@
-from .hdf5dataset import *
-from .illustris_kappa import *
-from .probes import *
+from . import hdf5dataset, illustris_kappa, probes
+
+__all__ = ["hdf5dataset", "illustris_kappa", "probes"]

--- a/src/caustics/data/__init__.py
+++ b/src/caustics/data/__init__.py
@@ -1,3 +1,5 @@
-from . import hdf5dataset, illustris_kappa, probes
+from .hdf5dataset import HDF5Dataset
+from .illustris_kappa import IllustrisKappaDataset
+from .probes import PROBESDataset
 
-__all__ = ["hdf5dataset", "illustris_kappa", "probes"]
+__all__ = ["HDF5Dataset", "IllustrisKappaDataset", "PROBESDataset"]

--- a/src/caustics/lenses/__init__.py
+++ b/src/caustics/lenses/__init__.py
@@ -1,13 +1,31 @@
-from .base import *
-from .epl import *
-from .external_shear import *
-from .pixelated_convergence import *
-from .multiplane import *
-from .nfw import *
-from .point import *
-from .pseudo_jaffe import *
-from .sie import *
-from .sis import *
-from .singleplane import *
-from .mass_sheet import *
-from .tnfw import *
+from .base import ThinLens, ThickLens
+from .epl import EPL
+from .external_shear import ExternalShear
+from .pixelated_convergence import PixelatedConvergence
+from .multiplane import Multiplane
+from .nfw import NFW
+from .point import Point
+from .pseudo_jaffe import PseudoJaffe
+from .sie import SIE
+from .sis import SIS
+from .singleplane import SinglePlane
+from .mass_sheet import MassSheet
+from .tnfw import TNFW
+
+
+__all__ = [
+    "ThinLens",
+    "ThickLens",
+    "EPL",
+    "ExternalShear",
+    "PixelatedConvergence",
+    "Multiplane",
+    "NFW",
+    "Point",
+    "PseudoJaffe",
+    "SIE",
+    "SIS",
+    "SinglePlane",
+    "MassSheet",
+    "TNFW",
+]

--- a/src/caustics/light/__init__.py
+++ b/src/caustics/light/__init__.py
@@ -1,4 +1,6 @@
-from .base import *
-from .pixelated import *
-from .probes import *
-from .sersic import *
+from .base import Source
+from .pixelated import Pixelated
+from .probes import PROBESDataset
+from .sersic import Sersic
+
+__all__ = ["Source", "Pixelated", "PROBESDataset", "Sersic"]

--- a/src/caustics/sims/__init__.py
+++ b/src/caustics/sims/__init__.py
@@ -1,2 +1,4 @@
-from .lens_source import *
-from .simulator import *
+from .lens_source import Lens_Source
+from .simulator import Simulator
+
+__all__ = ["Lens_Source", "Simulator"]


### PR DESCRIPTION
Update all * imports to be more explicit of the
classes/functions being imported, which fixes
PEP8 F403 violation.