### PR TITLE
fix: Fixed missing parameters in "dynamic"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 exclude: |
   (?x)^(
+    tests/helpers/|
     tests/utils.py
   )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,3 +61,6 @@ local_scheme = "no-local-version"
 [tool.ruff]
 # Same as Black.
 line-length = 100
+
+[tool.pytest.ini_options]
+norecursedirs = "tests/helpers"

--- a/src/caustics/sims/state_dict.py
+++ b/src/caustics/sims/state_dict.py
@@ -68,9 +68,10 @@ class StateDict(OrderedDict):
         state_dict_list = [
             (k, v) if v.nelement() > 0 else (k, None) for k, v in self.items()
         ]
+        class_name = self.__class__.__name__
         if not state_dict_list:
-            return "%s()" % (self.__class__.__name__,)
-        return "%s(%r)" % (self.__class__.__name__, state_dict_list)
+            return "%s()" % (class_name,)
+        return "%s(%r)" % (class_name, state_dict_list)
 
     @classmethod
     def from_params(cls, params: "NestedNamespaceDict | NamespaceDict"):

--- a/src/caustics/sims/state_dict.py
+++ b/src/caustics/sims/state_dict.py
@@ -1,15 +1,38 @@
 from datetime import datetime as dt
 from collections import OrderedDict
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from torch import Tensor
+import torch
 from .._version import __version__
 from ..namespace_dict import NamespaceDict, NestedNamespaceDict
 
 from safetensors.torch import save
 
 IMMUTABLE_ERR = TypeError("'StateDict' cannot be modified after creation.")
-STATIC_PARAMS = "static"
+PARAM_KEYS = ["dynamic", "static"]
+
+
+def _sanitize(tensors_dict: Dict[str, Optional[Tensor]]) -> Dict[str, Tensor]:
+    """
+    Sanitize the input dictionary of tensors by
+    replacing Nones with tensors of size 0.
+
+    Parameters
+    ----------
+    tensors_dict : dict
+        A dictionary of tensors, including None.
+
+    Returns
+    -------
+    dict
+        A dictionary of tensors, with empty tensors
+        replaced by tensors of size 0.
+    """
+    return {
+        k: v if isinstance(v, Tensor) else torch.ones(0)
+        for k, v in tensors_dict.items()
+    }
 
 
 class StateDict(OrderedDict):
@@ -41,6 +64,14 @@ class StateDict(OrderedDict):
             raise IMMUTABLE_ERR
         super().__setitem__(key, value)
 
+    def __repr__(self) -> str:
+        state_dict_list = [
+            (k, v) if v.nelement() > 0 else (k, None) for k, v in self.items()
+        ]
+        if not state_dict_list:
+            return "%s()" % (self.__class__.__name__,)
+        return "%s(%r)" % (self.__class__.__name__, state_dict_list)
+
     @classmethod
     def from_params(cls, params: "NestedNamespaceDict | NamespaceDict"):
         """Class method to create a StateDict
@@ -59,26 +90,55 @@ class StateDict(OrderedDict):
         StateDict
             A state dictionary object
         """
-        if isinstance(params, NestedNamespaceDict) and STATIC_PARAMS in params:
-            params: NamespaceDict = params[STATIC_PARAMS].flatten()
-        tensors_dict: Dict[str, Tensor] = {k: v.value for k, v in params.items()}
+        if not isinstance(params, (NamespaceDict, NestedNamespaceDict)):
+            raise TypeError("params must be a NamespaceDict or NestedNamespaceDict")
+
+        if isinstance(params, NestedNamespaceDict):
+            # In this case, params is the full parameters
+            # with both "static" and "dynamic" keys
+            if sorted(params.keys()) != PARAM_KEYS:
+                raise ValueError(f"params must have keys {PARAM_KEYS}")
+
+            # Extract the "static" and "dynamic" parameters
+            param_dicts = list(params.values())
+
+            # Extract the "static" and "dynamic" parameters
+            # to a single merged dictionary
+            final_dict = NestedNamespaceDict()
+            for pdict in param_dicts:
+                for k, v in pdict.items():
+                    if k not in final_dict:
+                        final_dict[k] = v
+                    else:
+                        final_dict[k] = {**final_dict[k], **v}
+
+            # Flatten the dictionary to a single level
+            params: NamespaceDict = final_dict.flatten()
+
+        tensors_dict: Dict[str, Tensor] = _sanitize(
+            {k: v.value for k, v in params.items()}
+        )
         return cls(tensors_dict)
 
-    def to_params(self) -> NamespaceDict:
+    def to_params(self) -> NestedNamespaceDict:
         """
-        Convert the state dict to a dictionary of parameters.
+        Convert the state dict to
+        a nested dictionary of parameters.
 
         Returns
         -------
-        NamespaceDict
-            A dictionary of 'static' parameters.
+        NestedNamespaceDict
+            A nested dictionary of parameters.
         """
         from ..parameter import Parameter
 
         params = NamespaceDict()
         for k, v in self.items():
+            if v.nelement() == 0:
+                # Set to None if the tensor is empty
+                v = None
             params[k] = Parameter(v)
-        return params
+        return NestedNamespaceDict(params)
 
     def _to_safetensors(self) -> bytes:
         return save(self, metadata=self._metadata)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+import os
+
+# Add the helpers directory to the path so we can import the helpers
+sys.path.append(os.path.join(os.path.dirname(__file__), "helpers"))

--- a/tests/helpers/sims.py
+++ b/tests/helpers/sims.py
@@ -1,0 +1,43 @@
+from caustics.namespace_dict import NestedNamespaceDict
+from caustics.sims.state_dict import _sanitize
+
+
+def extract_tensors(params, include_params=False):
+    # Extract the "static" and "dynamic" parameters
+    param_dicts = list(params.values())
+
+    # Extract the "static" and "dynamic" parameters
+    # to a single merged dictionary
+    final_dict = NestedNamespaceDict()
+    for pdict in param_dicts:
+        for k, v in pdict.items():
+            if k not in final_dict:
+                final_dict[k] = v
+            else:
+                final_dict[k] = {**final_dict[k], **v}
+
+    # flatten function only exists for NestedNamespaceDict
+    all_params = final_dict.flatten()
+
+    tensors_dict = _sanitize({k: v.value for k, v in all_params.items()})
+    if include_params:
+        return tensors_dict, all_params
+    return tensors_dict
+
+
+def isEquals(a, b):
+    # Go through each key and values
+    # change empty torch to be None
+    # since we can't directly compare
+    # empty torch
+    truthy = []
+    for k, v in a.items():
+        if k not in b:
+            return False
+        kv = b[k]
+        if (v.nelement() == 0) or (kv.nelement() == 0):
+            v = None
+            kv = None
+        truthy.append(v == kv)
+
+    return all(truthy)

--- a/tests/sims/conftest.py
+++ b/tests/sims/conftest.py
@@ -4,6 +4,56 @@ from caustics.sims.simulator import Simulator
 from caustics.lenses import EPL
 from caustics.light import Sersic
 from caustics.cosmology import FlatLambdaCDM
+from caustics.namespace_dict import NestedNamespaceDict
+from caustics.sims.state_dict import _sanitize
+
+
+class SimUtilities:
+    @staticmethod
+    def extract_tensors(params, include_params=False):
+        # Extract the "static" and "dynamic" parameters
+        param_dicts = list(params.values())
+
+        # Extract the "static" and "dynamic" parameters
+        # to a single merged dictionary
+        final_dict = NestedNamespaceDict()
+        for pdict in param_dicts:
+            for k, v in pdict.items():
+                if k not in final_dict:
+                    final_dict[k] = v
+                else:
+                    final_dict[k] = {**final_dict[k], **v}
+
+        # flatten function only exists for NestedNamespaceDict
+        all_params = final_dict.flatten()
+
+        tensors_dict = _sanitize({k: v.value for k, v in all_params.items()})
+        if include_params:
+            return tensors_dict, all_params
+        return tensors_dict
+
+    @staticmethod
+    def isEquals(a, b):
+        # Go through each key and values
+        # change empty torch to be None
+        # since we can't directly compare
+        # empty torch
+        truthy = []
+        for k, v in a.items():
+            if k not in b:
+                return False
+            kv = b[k]
+            if (v.nelement() == 0) or (kv.nelement() == 0):
+                v = None
+                kv = None
+            truthy.append(v == kv)
+
+        return all(truthy)
+
+
+@pytest.fixture
+def sim_utils():
+    return SimUtilities
 
 
 @pytest.fixture

--- a/tests/sims/conftest.py
+++ b/tests/sims/conftest.py
@@ -4,56 +4,6 @@ from caustics.sims.simulator import Simulator
 from caustics.lenses import EPL
 from caustics.light import Sersic
 from caustics.cosmology import FlatLambdaCDM
-from caustics.namespace_dict import NestedNamespaceDict
-from caustics.sims.state_dict import _sanitize
-
-
-class SimUtilities:
-    @staticmethod
-    def extract_tensors(params, include_params=False):
-        # Extract the "static" and "dynamic" parameters
-        param_dicts = list(params.values())
-
-        # Extract the "static" and "dynamic" parameters
-        # to a single merged dictionary
-        final_dict = NestedNamespaceDict()
-        for pdict in param_dicts:
-            for k, v in pdict.items():
-                if k not in final_dict:
-                    final_dict[k] = v
-                else:
-                    final_dict[k] = {**final_dict[k], **v}
-
-        # flatten function only exists for NestedNamespaceDict
-        all_params = final_dict.flatten()
-
-        tensors_dict = _sanitize({k: v.value for k, v in all_params.items()})
-        if include_params:
-            return tensors_dict, all_params
-        return tensors_dict
-
-    @staticmethod
-    def isEquals(a, b):
-        # Go through each key and values
-        # change empty torch to be None
-        # since we can't directly compare
-        # empty torch
-        truthy = []
-        for k, v in a.items():
-            if k not in b:
-                return False
-            kv = b[k]
-            if (v.nelement() == 0) or (kv.nelement() == 0):
-                v = None
-                kv = None
-            truthy.append(v == kv)
-
-        return all(truthy)
-
-
-@pytest.fixture
-def sim_utils():
-    return SimUtilities
 
 
 @pytest.fixture

--- a/tests/sims/test_simulator.py
+++ b/tests/sims/test_simulator.py
@@ -9,13 +9,12 @@ def state_dict(simple_common_sim):
 
 
 @pytest.fixture
-def expected_tensors(simple_common_sim):
-    static_params = simple_common_sim.params["static"].flatten()
-    return {k: v.value for k, v in static_params.items()}
+def expected_tensors(simple_common_sim, sim_utils):
+    return sim_utils.extract_tensors(simple_common_sim.params)
 
 
 class TestSimulator:
-    def test_state_dict(self, state_dict, expected_tensors):
+    def test_state_dict(self, state_dict, expected_tensors, sim_utils):
         # Check state_dict type and default keys
         assert isinstance(state_dict, StateDict)
 
@@ -28,4 +27,4 @@ class TestSimulator:
         assert "created_time" in state_dict._metadata
 
         # Check params
-        assert dict(state_dict) == expected_tensors
+        assert sim_utils.isEquals(dict(state_dict), expected_tensors)

--- a/tests/sims/test_simulator.py
+++ b/tests/sims/test_simulator.py
@@ -1,6 +1,7 @@
 import pytest
 
 from caustics.sims.state_dict import StateDict
+from helpers.sims import extract_tensors, isEquals
 
 
 @pytest.fixture
@@ -9,12 +10,12 @@ def state_dict(simple_common_sim):
 
 
 @pytest.fixture
-def expected_tensors(simple_common_sim, sim_utils):
-    return sim_utils.extract_tensors(simple_common_sim.params)
+def expected_tensors(simple_common_sim):
+    return extract_tensors(simple_common_sim.params)
 
 
 class TestSimulator:
-    def test_state_dict(self, state_dict, expected_tensors, sim_utils):
+    def test_state_dict(self, state_dict, expected_tensors):
         # Check state_dict type and default keys
         assert isinstance(state_dict, StateDict)
 
@@ -27,4 +28,4 @@ class TestSimulator:
         assert "created_time" in state_dict._metadata
 
         # Check params
-        assert sim_utils.isEquals(dict(state_dict), expected_tensors)
+        assert isEquals(dict(state_dict), expected_tensors)

--- a/tests/sims/test_state_dict.py
+++ b/tests/sims/test_state_dict.py
@@ -5,7 +5,7 @@ from safetensors.torch import save, load
 from datetime import datetime as dt
 from caustics.parameter import Parameter
 from caustics.namespace_dict import NamespaceDict, NestedNamespaceDict
-from caustics.sims.state_dict import StateDict, IMMUTABLE_ERR
+from caustics.sims.state_dict import StateDict, IMMUTABLE_ERR, _sanitize
 from caustics import __version__
 
 
@@ -43,21 +43,52 @@ class TestStateDict:
     def test_from_params(self, simple_common_sim):
         params: NestedNamespaceDict = simple_common_sim.params
 
+        # Extract the "static" and "dynamic" parameters
+        param_dicts = list(params.values())
+
+        # Extract the "static" and "dynamic" parameters
+        # to a single merged dictionary
+        final_dict = NestedNamespaceDict()
+        for pdict in param_dicts:
+            for k, v in pdict.items():
+                if k not in final_dict:
+                    final_dict[k] = v
+                else:
+                    final_dict[k] = {**final_dict[k], **v}
+
         # flatten function only exists for NestedNamespaceDict
-        static_params: NamespaceDict = params["static"].flatten()
-        tensors_dict: Dict[str, torch.Tensor] = {
-            k: v.value for k, v in static_params.items()
-        }
+        all_params = final_dict.flatten()
+
+        tensors_dict: Dict[str, torch.Tensor] = _sanitize(
+            {k: v.value for k, v in all_params.items()}
+        )
 
         expected_state_dict = StateDict(tensors_dict)
 
+        def isEquals(a, b):
+            # Go through each key and values
+            # change empty torch to be None
+            # since we can't directly compare
+            # empty torch
+            truthy = []
+            for k, v in a.items():
+                if k not in b:
+                    return False
+                kv = b[k]
+                if (v.nelement() == 0) or (kv.nelement() == 0):
+                    v = None
+                    kv = None
+                truthy.append(v == kv)
+
+            return all(truthy)
+
         # Full parameters
         state_dict = StateDict.from_params(params)
-        assert state_dict == expected_state_dict
+        assert isEquals(state_dict, expected_state_dict)
 
         # Static only
-        state_dict = StateDict.from_params(static_params)
-        assert state_dict == expected_state_dict
+        state_dict = StateDict.from_params(all_params)
+        assert isEquals(state_dict, expected_state_dict)
 
     def test_to_params(self, simple_state_dict):
         params = simple_state_dict.to_params()

--- a/tests/sims/test_state_dict.py
+++ b/tests/sims/test_state_dict.py
@@ -7,6 +7,8 @@ from caustics.namespace_dict import NamespaceDict, NestedNamespaceDict
 from caustics.sims.state_dict import StateDict, IMMUTABLE_ERR
 from caustics import __version__
 
+from helpers.sims import extract_tensors, isEquals
+
 
 class TestStateDict:
     simple_tensors = {"var1": torch.as_tensor(1.0), "var2": torch.as_tensor(2.0)}
@@ -39,20 +41,20 @@ class TestStateDict:
         with pytest.raises(type(IMMUTABLE_ERR), match=str(IMMUTABLE_ERR)):
             del simple_state_dict["var1"]
 
-    def test_from_params(self, simple_common_sim, sim_utils):
+    def test_from_params(self, simple_common_sim):
         params: NestedNamespaceDict = simple_common_sim.params
 
-        tensors_dict, all_params = sim_utils.extract_tensors(params, True)
+        tensors_dict, all_params = extract_tensors(params, True)
 
         expected_state_dict = StateDict(tensors_dict)
 
         # Full parameters
         state_dict = StateDict.from_params(params)
-        assert sim_utils.isEquals(state_dict, expected_state_dict)
+        assert isEquals(state_dict, expected_state_dict)
 
         # Static only
         state_dict = StateDict.from_params(all_params)
-        assert sim_utils.isEquals(state_dict, expected_state_dict)
+        assert isEquals(state_dict, expected_state_dict)
 
     def test_to_params(self, simple_state_dict):
         params = simple_state_dict.to_params()


### PR DESCRIPTION
## Overview

During a call, Connor mentioned that we'll need to store the values within the "dynamic" section of parameters, rather than only "static". This is due to the fact that for some classes such as `Cosmology` there is currently a default value, but there may be a case that a user specifies a `None` to `h0` as such:

```python
import caustics

cosmology = caustics.cosmology.FlatLambdaCDM(name="cosmo")
cosmology.h0 = None
```

Doing the above would put `h0` parameter to be "dynamic" instead of originally be "static", would need to save this, otherwise, by default it will have a value, which is not wanted.

This PR fixes the original `StateDict` that only grabs the "static" parameters. Now it also grabs the "dynamic" parameters. Also I introduced `_sanitize` function to make `None` to empty tensor of size 0 internally, since safetensors format doesn't except `None`.