### PR TITLE
feat: Added functionalities to save and load StateDict to and from a safetensors

### DIFF
--- a/.devcontainer/cpu/devcontainer.json
+++ b/.devcontainer/cpu/devcontainer.json
@@ -6,8 +6,8 @@
     "context": "../..",
     "dockerfile": "../Dockerfile",
     "args": {
-      "CLANG_VERSION": ""
-    }
+      "CLANG_VERSION": "",
+    },
   },
 
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
@@ -26,10 +26,10 @@
         "ms-python.python",
         "ms-vsliveshare.vsliveshare",
         "DavidAnson.vscode-markdownlint",
-        "GitHub.copilot"
-      ]
-    }
-  }
+        "GitHub.copilot",
+      ],
+    },
+  },
 
   // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
   // "remoteUser": "root"

--- a/src/caustics/io.py
+++ b/src/caustics/io.py
@@ -4,7 +4,7 @@ DEFAULT_ENCODING = "utf-8"
 
 
 def to_file(
-    path: str | Path, data: str | bytes, encoding: str = DEFAULT_ENCODING
+    path: "str | Path", data: "str | bytes", encoding: str = DEFAULT_ENCODING
 ) -> str:
     """
     Save data string or bytes to specified file path

--- a/src/caustics/io.py
+++ b/src/caustics/io.py
@@ -1,6 +1,16 @@
 from pathlib import Path
+import json
+import struct
 
 DEFAULT_ENCODING = "utf-8"
+SAFETENSORS_METADATA = "__metadata__"
+
+
+def _normalize_path(path: "str | Path") -> Path:
+    # Convert string path to Path object
+    if isinstance(path, str):
+        path = Path(path)
+    return path
 
 
 def to_file(
@@ -29,9 +39,84 @@ def to_file(
     if isinstance(data, str):
         data = data.encode(encoding)
 
-    # Convert string path to Path object
-    if isinstance(path, str):
-        path = Path(path)
+    # Normalize path to pathlib.Path object
+    path = _normalize_path(path)
 
     path.write_bytes(data)
     return str(path.absolute())
+
+
+def from_file(path: "str | Path") -> bytes:
+    """
+    Load data from specified file path
+
+    Parameters
+    ----------
+    path : str or Path
+        The path to load the data from
+
+    Returns
+    -------
+    bytes
+        The data bytes loaded from the file
+    """
+    # TODO: Update to allow for remote paths loading
+
+    # Normalize path to pathlib.Path object
+    path = _normalize_path(path)
+
+    return path.read_bytes()
+
+
+def _get_safetensors_header(path: "str | Path") -> dict:
+    """
+    Read specified file header to a dictionary
+
+    Parameters
+    ----------
+    path : str or Path
+        The path to get header from
+
+    Returns
+    -------
+    dict
+        The header dictionary
+    """
+    # TODO: Update to allow for remote paths loading of header
+
+    # Normalize path to pathlib.Path object
+    path = _normalize_path(path)
+
+    # Doing this avoids reading the whole safetensors
+    # file in case that it's large
+    with open(path, "rb") as f:
+        # Get the size of the header by reading first 8 bytes
+        (length_of_header,) = struct.unpack("<Q", f.read(8))
+
+        # Get the full header
+        header = json.loads(f.read(length_of_header))
+
+        # Only return the metadata
+        # if it's not even there, just return blank dict
+        return header
+
+
+def get_safetensors_metadata(path: "str | Path") -> dict:
+    """
+    Get the metadata from the specified file path
+
+    Parameters
+    ----------
+    path : str or Path
+        The path to get the metadata from
+
+    Returns
+    -------
+    dict
+        The metadata dictionary
+    """
+    header = _get_safetensors_header(path)
+
+    # Only return the metadata
+    # if it's not even there, just return blank dict
+    return header.get(SAFETENSORS_METADATA, {})

--- a/src/caustics/io.py
+++ b/src/caustics/io.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+DEFAULT_ENCODING = "utf-8"
+
+
+def to_file(
+    path: str | Path, data: str | bytes, encoding: str = DEFAULT_ENCODING
+) -> str:
+    """
+    Save data string or bytes to specified file path
+
+    Parameters
+    ----------
+    path : str or Path
+        The path to save the data to
+    data : str | bytes
+        The data string or bytes to save to file
+    encoding : str, optional
+        The string encoding to use, by default "utf-8"
+
+    Returns
+    -------
+    str
+        The path string where the data is saved
+    """
+    # TODO: Update to allow for remote paths saving
+
+    # Convert string data to bytes
+    if isinstance(data, str):
+        data = data.encode(encoding)
+
+    # Convert string path to Path object
+    if isinstance(path, str):
+        path = Path(path)
+
+    path.write_bytes(data)
+    return str(path.absolute())

--- a/src/caustics/sims/simulator.py
+++ b/src/caustics/sims/simulator.py
@@ -1,5 +1,10 @@
+from pathlib import Path
+from typing import Dict
+from torch import Tensor
+
 from ..parametrized import Parametrized
 from .state_dict import StateDict
+from ..namespace_dict import NestedNamespaceDict
 
 __all__ = ("Simulator",)
 
@@ -27,5 +32,67 @@ class Simulator(Parametrized):
 
         return self.forward(packed_args, *rest_args, **kwargs)
 
+    @staticmethod
+    def __set_module_params(module: Parametrized, params: Dict[str, Tensor]):
+        for k, v in params.items():
+            setattr(module, k, v)
+
     def state_dict(self) -> StateDict:
         return StateDict.from_params(self.params)
+
+    def load_state_dict(self, file_path: "str | Path") -> "Simulator":
+        """
+        Loads and then sets the state of the simulator from a file
+
+        Parameters
+        ----------
+        file_path : str | Path
+            The file path to a safetensors file
+            to load the state from
+
+        Returns
+        -------
+        Simulator
+            The simulator with the loaded state
+        """
+        loaded_state_dict = StateDict.load(file_path)
+        self.set_state_dict(loaded_state_dict)
+        return self
+
+    def set_state_dict(self, state_dict: StateDict) -> "Simulator":
+        """
+        Sets the state of the simulator from a state dict
+
+        Parameters
+        ----------
+        state_dict : StateDict
+            The state dict to load from
+
+        Returns
+        -------
+        Simulator
+            The simulator with the loaded state
+        """
+        # TODO: Do some checks for the state dict metadata
+
+        # Convert to nested namespace dict
+        param_dicts = NestedNamespaceDict(state_dict)
+
+        # Grab params for the current module
+        self_params = param_dicts.pop(self.name)
+
+        def _set_params(module):
+            # Start from root, and move down the DAG
+            if module.name in param_dicts:
+                module_params = param_dicts[module.name]
+                self.__set_module_params(module, module_params)
+            if module._childs != {}:
+                for child in module._childs.values():
+                    _set_params(child)
+
+        # Set the parameters of the current module
+        self.__set_module_params(self, self_params)
+
+        # Set the parameters of the children modules
+        _set_params(self)
+        return self

--- a/src/caustics/sims/state_dict.py
+++ b/src/caustics/sims/state_dict.py
@@ -1,10 +1,12 @@
 from datetime import datetime as dt
 from collections import OrderedDict
-from typing import Any, Dict
+from typing import Any, Dict, Optional
+from pathlib import Path
 
 from torch import Tensor
 from .._version import __version__
 from ..namespace_dict import NamespaceDict, NestedNamespaceDict
+from .. import io
 
 from safetensors.torch import save
 
@@ -12,7 +14,26 @@ IMMUTABLE_ERR = TypeError("'StateDict' cannot be modified after creation.")
 STATIC_PARAMS = "static"
 
 
-class StateDict(OrderedDict):
+class ImmutableODict(OrderedDict):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._created = True
+
+    def __delitem__(self, _) -> None:
+        raise IMMUTABLE_ERR
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        if hasattr(self, "_created"):
+            raise IMMUTABLE_ERR
+        super().__setitem__(key, value)
+
+    def __setattr__(self, name, value) -> None:
+        if hasattr(self, "_created"):
+            raise IMMUTABLE_ERR
+        return super().__setattr__(name, value)
+
+
+class StateDict(ImmutableODict):
     """A dictionary object that is immutable after creation.
     This is used to store the parameters of a simulator at a given
     point in time.
@@ -23,23 +44,22 @@ class StateDict(OrderedDict):
         Convert the state dict to a dictionary of parameters.
     """
 
-    __slots__ = ("_metadata", "_created")
+    __slots__ = ("_metadata", "_created", "_created_time")
 
     def __init__(self, *args, **kwargs):
+        # Get created time
+        self._created_time = dt.now()
+        # Create metadata
+        metadata = {
+            "software_version": __version__,
+            "created_time": self._created_time.isoformat(),
+        }
+        # Set metadata
+        self._metadata = ImmutableODict(metadata)
+
+        # Now create the object, this will set _created
+        # to True, and prevent any further modification
         super().__init__(*args, **kwargs)
-
-        self._metadata = {}
-        self._metadata["software_version"] = __version__
-        self._metadata["created_time"] = dt.utcnow().isoformat()
-        self._created = True
-
-    def __delitem__(self, _) -> None:
-        raise IMMUTABLE_ERR
-
-    def __setitem__(self, key: str, value: Any) -> None:
-        if hasattr(self, "_created"):
-            raise IMMUTABLE_ERR
-        super().__setitem__(key, value)
 
     @classmethod
     def from_params(cls, params: "NestedNamespaceDict | NamespaceDict"):
@@ -79,6 +99,44 @@ class StateDict(OrderedDict):
         for k, v in self.items():
             params[k] = Parameter(v)
         return params
+
+    def save(self, file_path: Optional[str] = None) -> str:
+        """
+        Saves the state dictionary to an optional
+        ``file_path`` as safetensors format.
+        If ``file_path`` is not given,
+        this will default to a file in
+        the current working directory.
+
+        *Note: The path specified must
+        have a '.st' extension.*
+
+        Parameters
+        ----------
+        file_path : str, optional
+            The file path to save the
+            state dictionary to, by default None
+
+        Returns
+        -------
+        str
+            The final path of the saved file
+        """
+        if not file_path:
+            file_path = Path(".") / self.__st_file
+        elif isinstance(file_path, str):
+            file_path = Path(file_path)
+
+        ext = ".st"
+        if file_path.suffix != ext:
+            raise ValueError(f"File must have '{ext}' extension")
+
+        return io.to_file(file_path, self._to_safetensors())
+
+    @property
+    def __st_file(self) -> str:
+        file_format = "%Y%m%dT%H%M%S_caustics.st"
+        return self._created_time.strftime(file_format)
 
     def _to_safetensors(self) -> bytes:
         return save(self, metadata=self._metadata)

--- a/src/caustics/sims/state_dict.py
+++ b/src/caustics/sims/state_dict.py
@@ -139,7 +139,7 @@ class StateDict(ImmutableODict):
             params: NamespaceDict = final_dict.flatten()
 
         tensors_dict: Dict[str, Tensor] = {k: v.value for k, v in params.items()}
-        return cls(metadata=None, **tensors_dict)
+        return cls(**tensors_dict)
 
     def to_params(self) -> NestedNamespaceDict:
         """

--- a/tests/helpers/sims.py
+++ b/tests/helpers/sims.py
@@ -19,25 +19,7 @@ def extract_tensors(params, include_params=False):
     # flatten function only exists for NestedNamespaceDict
     all_params = final_dict.flatten()
 
-    tensors_dict = _sanitize({k: v.value for k, v in all_params.items()})
+    tensors_dict = {k: v.value for k, v in all_params.items()}
     if include_params:
         return tensors_dict, all_params
     return tensors_dict
-
-
-def isEquals(a, b):
-    # Go through each key and values
-    # change empty torch to be None
-    # since we can't directly compare
-    # empty torch
-    truthy = []
-    for k, v in a.items():
-        if k not in b:
-            return False
-        kv = b[k]
-        if (v.nelement() == 0) or (kv.nelement() == 0):
-            v = None
-            kv = None
-        truthy.append(v == kv)
-
-    return all(truthy)

--- a/tests/helpers/sims.py
+++ b/tests/helpers/sims.py
@@ -1,5 +1,4 @@
 from caustics.namespace_dict import NestedNamespaceDict
-from caustics.sims.state_dict import _sanitize
 
 
 def extract_tensors(params, include_params=False):

--- a/tests/sims/test_simulator.py
+++ b/tests/sims/test_simulator.py
@@ -1,7 +1,7 @@
 import pytest
 
 from caustics.sims.state_dict import StateDict
-from helpers.sims import extract_tensors, isEquals
+from helpers.sims import extract_tensors
 
 
 @pytest.fixture
@@ -28,4 +28,4 @@ class TestSimulator:
         assert "created_time" in state_dict._metadata
 
         # Check params
-        assert isEquals(dict(state_dict), expected_tensors)
+        assert dict(state_dict) == expected_tensors


### PR DESCRIPTION
## Overview

We now have a way to extract a state dictionary from `Simulator`, this PR adds a way to save that state dictionary to a safetensors file. This starts with the creation of `io` module. In addition, this PR also cracks down on ensuring that `StateDict` object can't be modified once created.